### PR TITLE
Added exec permission to initialize-repository.sh

### DIFF
--- a/.github/workflows/2-setup-azure-environment.yml
+++ b/.github/workflows/2-setup-azure-environment.yml
@@ -107,7 +107,9 @@ jobs:
 
       # Pull main.
       - name: Pull main
-        run: ./.github/script/pull-main.sh
+        run: |
+          chmod +x ./.github/script/initialize-repository.sh
+          ./.github/script/initialize-repository.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/3-spinup-environment.yml
+++ b/.github/workflows/3-spinup-environment.yml
@@ -63,7 +63,9 @@ jobs:
 
       # Pull main.
       - name: Pull main
-        run: ./.github/script/pull-main.sh
+        run: |
+          chmod +x ./.github/script/initialize-repository.sh
+          ./.github/script/initialize-repository.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/4-deploy-to-staging-environment.yml
+++ b/.github/workflows/4-deploy-to-staging-environment.yml
@@ -61,7 +61,9 @@ jobs:
 
       # Pull main.
       - name: Pull main
-        run: ./.github/script/pull-main.sh
+        run: |
+          chmod +x ./.github/script/initialize-repository.sh
+          ./.github/script/initialize-repository.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Summary

Fixed issues related to the "Pull Main" job on all files that contain it.

### Changes

Added the execute permission and path to the script.

This doesnt work properly when trying to do the course:
```
run: ./.github/script/pull-main.sh
```

My solution: (applied on all files that corresponds)
```
run: |
  chmod +x ./.github/script/initialize-repository.sh
  ./.github/script/initialize-repository.sh
```

### Conclusion

* This fix enables course completion.
* It works with almost all GitHub Actions, except for the `production-deployment-workflow` merge, which is affected by the node.js version. However, even if this specific GitHub Action fails, it won't hinder course progress.
