### PR TITLE
Fix build job by downgrading to node 16

### DIFF
--- a/.github/steps/2-setup-azure-environment.md
+++ b/.github/steps/2-setup-azure-environment.md
@@ -107,6 +107,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: npm install and build webpack
         run: |
           npm install

--- a/.github/steps/5-deploy-to-prod-environment.md
+++ b/.github/steps/5-deploy-to-prod-environment.md
@@ -43,6 +43,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: npm install and build webpack
         run: |
           npm install


### PR DESCRIPTION
See https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported

With system node version (18) error is:

Run `npm audit` for details.

> actions-template@1.0.0 build
> npx webpack --config ./src/webpack.config.js --mode production

node:internal/crypto/hash:69
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/webpack/lib/util/createHash.js:1[35](https://github.com/jlahtinen/skills-deploy-to-azure/actions/runs/6250540242/job/16969630247#step:3:36):53)
    at NormalModule._initBuildHash (/home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/webpack/lib/NormalModule.js:414:16)
    at handleParseError (/home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/webpack/lib/NormalModule.js:467:10)
    at /home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/webpack/lib/NormalModule.js:499:5
    at /home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/webpack/lib/NormalModule.js:356:12
    at /home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/loader-runner/lib/LoaderRunner.js:[37](https://github.com/jlahtinen/skills-deploy-to-azure/actions/runs/6250540242/job/16969630247#step:3:38)3:3
    at iterateNormalLoaders (/home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at Array.<anonymous> (/home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
    at Storage.finished (/home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:[55](https://github.com/jlahtinen/skills-deploy-to-azure/actions/runs/6250540242/job/16969630247#step:3:56):16)
    at /home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
    at /home/runner/work/skills-deploy-to-azure/skills-deploy-to-azure/node_modules/graceful-fs/graceful-fs.js:123:16
    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.17.1
Error: Process completed with exit code 1.