### PR TITLE
Changed Azure region

### DIFF
--- a/.github/steps/3-spinup-environment.md
+++ b/.github/steps/3-spinup-environment.md
@@ -47,7 +47,7 @@ env:
   IMAGE_REGISTRY_URL: ghcr.io
   AZURE_RESOURCE_GROUP: cd-with-actions
   AZURE_APP_PLAN: actions-ttt-deployment
-  AZURE_LOCATION: '"Central US"'
+  AZURE_LOCATION: '"East US"'
   ###############################################
   ### Replace <username> with GitHub username ###
   ###############################################


### PR DESCRIPTION
Changed Azure region

### Summary
Changed the Azure region because US-Central has a quota of 0 instances for free accounts.


### Changes
Changed the Azure region from US-Central to US-East in .github/steps/3-spinup-environment.md.


Closes: #65 

### Task list

- [ +] For workflow changes, I have verified the Actions workflows function as expected.
- [ +] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
