### PR TITLE
Removed deprecated flag --sdk-auth

### DIFF
--- a/.github/steps/2-setup-azure-environment.md
+++ b/.github/steps/2-setup-azure-environment.md
@@ -52,8 +52,7 @@ We won't be going into detail on the steps of this workflow, but it would be a g
 
     ````shell
     az ad sp create-for-rbac --name "GitHub-Actions" --role contributor \
-     --scopes /subscriptions/{subscription-id} \
-     --sdk-auth
+     --scopes /subscriptions/{subscription-id}
 
         # Replace {subscription-id} with the same id stored in AZURE_SUBSCRIPTION_ID.
         ```

--- a/.github/steps/2-setup-azure-environment.md
+++ b/.github/steps/2-setup-azure-environment.md
@@ -61,13 +61,13 @@ We won't be going into detail on the steps of this workflow, but it would be a g
 
     ````
 
-1.  Copy the entire contents of the command's response, we'll call this `AZURE_CREDENTIALS`. Here's an example of what it looks like:
+1.  Copy the entire contents of the command's response, we'll store it as secrets to authorize in Azure. Here's an example of what it looks like:
     ```shell
     {
-      "clientId": "<GUID>",
-      "clientSecret": "<GUID>",
-      "subscriptionId": "<GUID>",
-      "tenantId": "<GUID>",
+      "appId": "<GUID>",
+      "displayName": "GitHub-Actions",
+      "password": "<GUID>",
+      "tenant": "<GUID>",
       (...)
     }
     ```
@@ -76,7 +76,10 @@ We won't be going into detail on the steps of this workflow, but it would be a g
 1.  Name your new secret **AZURE_SUBSCRIPTION_ID** and paste the value from the `id:` field in the first command.
 1.  Click **Add secret**.
 1.  Click **New repository secret** again.
-1.  Name the second secret **AZURE_CREDENTIALS** and paste the entire contents from the second terminal command you entered.
+1.  Name the second secret **AZURE_CLIENT_ID** and paste the value from the `appId:` field from the second terminal command you entered.
+1.  Click **Add secret**
+1.  Click **New repository secret** again.
+1.  Name the third secret **AZURE_TENANT_ID** and paste the value from the `tenant:` field from the second terminal command you entered.
 1.  Click **Add secret**
 1.  Go back to the Pull requests tab and in your pull request go to the **Files Changed** tab. Find and then edit the `.github/workflows/deploy-staging.yml` file to use some new actions.
 
@@ -163,7 +166,9 @@ jobs:
       - name: "Login via Azure CLI"
         uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - uses: azure/docker-login@v1
         with:


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
The flag --sdk-auth for **az ad sp** command has been deprecated and will be removed in a future release
A warning will be issued if this step is executed in the lab.
![image](https://github.com/skills/deploy-to-azure/assets/94014904/fe14e715-1dce-4ffb-b8f9-049d6f84ba7a)


### Changes
<!-- Describe the changes this pull request introduces. -->
Removing the deprecated --sdk-auth flag for Step 2

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

**Please also take a look at this comment: [issue](https://github.com/Azure/azure-cli/issues/20743#issuecomment-2063467956), since the problem becomes bigger - it's not possible to authorize with azure/login Action using the az ad sp (without --sdk-auth), because the outputs are not valid for AZURE_CREDENTIALS**

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
