### PR TITLE
Fix regular expressions escaping in a workflow

### DIFF
--- a/.github/workflows/1-configure-label-based-job.yml
+++ b/.github/workflows/1-configure-label-based-job.yml
@@ -60,7 +60,7 @@ jobs:
         uses: skills/action-check-file@v1
         with:
           file: .github/workflows/deploy-staging.yml
-          search: "github.event.pull_request.labels\\.\\*.name.*stage"
+          search: "github\\.event\\.pull_request\\.labels\\.\\*\\.name.*stage"
 
       # In README.md, switch step 1 for step 2.
       - name: Update to step 2


### PR DESCRIPTION
Escape `.` to `\\.`

### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
Fix regular expressions escaping in a workflow

### Changes
<!-- Describe the changes this pull request introduces. -->
`.` &rarr; `\\.`

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
