### PR TITLE
Fix CLI command provided in step 2

### DIFF
--- a/.github/steps/2-setup-azure-environment.md
+++ b/.github/steps/2-setup-azure-environment.md
@@ -50,16 +50,14 @@ We won't be going into detail on the steps of this workflow, but it would be a g
     ```
 1.  In your terminal, run the command below.
 
-    ````shell
+    ```shell
     az ad sp create-for-rbac --name "GitHub-Actions" --role contributor \
      --scopes /subscriptions/{subscription-id}
 
         # Replace {subscription-id} with the same id stored in AZURE_SUBSCRIPTION_ID.
-        ```
+    ```
 
-    > **Note**: The `\` character works as a line break on Unix based systems. If you are on a Windows based system the `\` character will cause this command to fail. Place this command on a single line if you are using Windows.\*\*
-
-    ````
+    > **Note**: The `\` character works as a line break on Unix based systems. If you are on a Windows based system the `\` character will cause this command to fail. Place this command on a single line if you are using Windows.
 
 1.  Copy the entire contents of the command's response, we'll store it as secrets to authorize in Azure. Here's an example of what it looks like:
     ```shell


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

There's a note that's not rendering properly as part of a CLI command the user is supposed to copy/paste. 

![Screenshot 2024-05-22 at 11 58 20 AM](https://github.com/skills/deploy-to-azure/assets/16547949/72a4ce08-0fed-4593-b4d2-73a25b8f3155)


### Changes
<!-- Describe the changes this pull request introduces. -->

Fixes indentation so the note is outside of the fenced code block. There's no issue for this. 

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
