### PR TITLE
Unbreak deployment workflows

### DIFF
--- a/.github/steps/1-configure-label-based-job.md
+++ b/.github/steps/1-configure-label-based-job.md
@@ -39,7 +39,6 @@ For now, we'll focus on staging. We'll spin up and destroy our environment in a 
 1. Name your workflow `deploy-staging.yml`
 1. Edit the contents of this file and remove all triggers and jobs.
 1. Edit the contents of the file to add a conditional that filters the `build` job when there is a label present called **stage**. Your resulting file should look like this:
-
    ```yaml
    name: Stage the app
 
@@ -53,7 +52,6 @@ For now, we'll focus on staging. We'll spin up and destroy our environment in a 
 
        if: contains(github.event.pull_request.labels.*.name, 'stage')
    ```
-
 1. Click **Start commit**, and choose to make a new branch named `staging-workflow`.
 1. Click **Propose changes**.
 1. Click **Create pull request**.

--- a/.github/steps/2-setup-azure-environment.md
+++ b/.github/steps/2-setup-azure-environment.md
@@ -31,22 +31,11 @@ We won't be going into detail on the steps of this workflow, but it would be a g
     ```shell
     az login
     ```
-1.  Copy the value of the `id:` field to a safe place. We'll call this `AZURE_SUBSCRIPTION_ID`. Here's an example of what it looks like:
+1.  Select the subscription you just selected from the interactive authentication prompt. Copy the value of the subscription id to a safe place. We'll call this `AZURE_SUBSCRIPTION_ID`. Here's an example of what it looks like:
     ```shell
-    [
-    {
-      "cloudName": "AzureCloud",
-      "id": "f****a09-****-4d1c-98**-f**********c", # <-- Copy this id field
-      "isDefault": true,
-      "name": "some-subscription-name",
-      "state": "Enabled",
-      "tenantId": "********-a**c-44**-**25-62*******61",
-      "user": {
-        "name": "mdavis******@*********.com",
-        "type": "user"
-        }
-      }
-    ]
+    No     Subscription name    Subscription ID                       Tenant
+    -----  -------------------  ------------------------------------  -----------------
+    [1] *  some-subscription    f****a09-****-4d1c-98**-f**********c  Default Directory
     ```
 1.  In your terminal, run the command below.
 

--- a/.github/steps/2-setup-azure-environment.md
+++ b/.github/steps/2-setup-azure-environment.md
@@ -122,7 +122,7 @@ We won't be going into detail on the steps of this workflow, but it would be a g
             with:
               registry: ${{ env.IMAGE_REGISTRY_URL }}
               username: ${{ github.actor }}
-              password: ${{ secrets.GITHUB_TOKEN }}
+              password: ${{ secrets.CR_PAT }}
 
           - name: Extract metadata (tags, labels) for Docker
             id: meta
@@ -154,7 +154,7 @@ We won't be going into detail on the steps of this workflow, but it would be a g
             with:
               login-server: ${{env.IMAGE_REGISTRY_URL}}
               username: ${{ github.actor }}
-              password: ${{ secrets.GITHUB_TOKEN }}
+              password: ${{ secrets.CR_PAT }}
 
           - name: Deploy web app container
             uses: azure/webapps-deploy@v3

--- a/.github/steps/2-setup-azure-environment.md
+++ b/.github/steps/2-setup-azure-environment.md
@@ -31,7 +31,7 @@ We won't be going into detail on the steps of this workflow, but it would be a g
     ```shell
     az login
     ```
-1.  Select the subscription you just selected from the interactive authentication prompt. Copy the value of the subscription id to a safe place. We'll call this `AZURE_SUBSCRIPTION_ID`. Here's an example of what it looks like:
+1.  Select the subscription you just selected from the interactive authentication prompt. Copy the value of the subscription ID to a safe place. We'll call this `AZURE_SUBSCRIPTION_ID`. Here's an example of what it looks like:
     ```shell
     No     Subscription name    Subscription ID                       Tenant
     -----  -------------------  ------------------------------------  -----------------

--- a/.github/steps/2-setup-azure-environment.md
+++ b/.github/steps/2-setup-azure-environment.md
@@ -52,20 +52,21 @@ We won't be going into detail on the steps of this workflow, but it would be a g
 
     ```shell
     az ad sp create-for-rbac --name "GitHub-Actions" --role contributor \
-     --scopes /subscriptions/{subscription-id}
+     --scopes /subscriptions/{subscription-id} \
+     --sdk-auth
 
         # Replace {subscription-id} with the same id stored in AZURE_SUBSCRIPTION_ID.
     ```
 
     > **Note**: The `\` character works as a line break on Unix based systems. If you are on a Windows based system the `\` character will cause this command to fail. Place this command on a single line if you are using Windows.
 
-1.  Copy the entire contents of the command's response, we'll store it as secrets to authorize in Azure. Here's an example of what it looks like:
+1.  Copy the entire contents of the command's response, we'll call this `AZURE_CREDENTIALS`. Here's an example of what it looks like:
     ```shell
     {
-      "appId": "<GUID>",
-      "displayName": "GitHub-Actions",
-      "password": "<GUID>",
-      "tenant": "<GUID>",
+      "clientId": "<GUID>",
+      "clientSecret": "<GUID>",
+      "subscriptionId": "<GUID>",
+      "tenantId": "<GUID>",
       (...)
     }
     ```
@@ -74,10 +75,7 @@ We won't be going into detail on the steps of this workflow, but it would be a g
 1.  Name your new secret **AZURE_SUBSCRIPTION_ID** and paste the value from the `id:` field in the first command.
 1.  Click **Add secret**.
 1.  Click **New repository secret** again.
-1.  Name the second secret **AZURE_CLIENT_ID** and paste the value from the `appId:` field from the second terminal command you entered.
-1.  Click **Add secret**
-1.  Click **New repository secret** again.
-1.  Name the third secret **AZURE_TENANT_ID** and paste the value from the `tenant:` field from the second terminal command you entered.
+1.  Name the second secret **AZURE_CREDENTIALS** and paste the entire contents from the second terminal command you entered.
 1.  Click **Add secret**
 1.  Go back to the Pull requests tab and in your pull request go to the **Files Changed** tab. Find and then edit the `.github/workflows/deploy-staging.yml` file to use some new actions.
 
@@ -164,9 +162,7 @@ jobs:
       - name: "Login via Azure CLI"
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - uses: azure/docker-login@v1
         with:

--- a/.github/steps/3-spinup-environment.md
+++ b/.github/steps/3-spinup-environment.md
@@ -32,84 +32,80 @@ Personal access tokens (PATs) are an alternative to using passwords for authenti
 To deploy successfully to our Azure environment:
 
 1. Create a new branch called `azure-configuration` by clicking on the branch dropdown on the top, left hand corner of the `Code` tab on your repository page.
-2. Once you're in the new `azure-configuration` branch, go into the `.github/workflows` directory and create a new file titled `spinup-destroy.yml` by clicking **Add file**.
+2. Once you're in the new `azure-configuration` branch, go into the `.github/workflows` directory and create a new file titled `spinup-destroy.yml` by clicking **Add file**. Copy and paste the following into this new file:
+    ```yaml
+    name: Configure Azure environment
 
-Copy and paste the following into this new file:
+    on:
+      pull_request:
+        types: [labeled]
 
-```yaml
-name: Configure Azure environment
+    env:
+      IMAGE_REGISTRY_URL: ghcr.io
+      AZURE_RESOURCE_GROUP: cd-with-actions
+      AZURE_APP_PLAN: actions-ttt-deployment
+      AZURE_LOCATION: '"East US"'
+      ###############################################
+      ### Replace <username> with GitHub username ###
+      ###############################################
+      AZURE_WEBAPP_NAME: <username>-ttt-app
 
-on:
-  pull_request:
-    types: [labeled]
+    jobs:
+      setup-up-azure-resources:
+        runs-on: ubuntu-latest
+        if: contains(github.event.pull_request.labels.*.name, 'spin up environment')
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@v4
 
-env:
-  IMAGE_REGISTRY_URL: ghcr.io
-  AZURE_RESOURCE_GROUP: cd-with-actions
-  AZURE_APP_PLAN: actions-ttt-deployment
-  AZURE_LOCATION: '"East US"'
-  ###############################################
-  ### Replace <username> with GitHub username ###
-  ###############################################
-  AZURE_WEBAPP_NAME: <username>-ttt-app
+          - name: Azure login
+            uses: azure/login@v2
+            with:
+              creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-jobs:
-  setup-up-azure-resources:
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'spin up environment')
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+          - name: Create Azure resource group
+            if: success()
+            run: |
+              az group create --location ${{env.AZURE_LOCATION}} --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
 
-      - name: Azure login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          - name: Create Azure app service plan
+            if: success()
+            run: |
+              az appservice plan create --resource-group ${{env.AZURE_RESOURCE_GROUP}} --name ${{env.AZURE_APP_PLAN}} --is-linux --sku F1 --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
 
-      - name: Create Azure resource group
-        if: success()
-        run: |
-          az group create --location ${{env.AZURE_LOCATION}} --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+          - name: Create webapp resource
+            if: success()
+            run: |
+              az webapp create --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --plan ${{ env.AZURE_APP_PLAN }} --name ${{ env.AZURE_WEBAPP_NAME }}  --deployment-container-image-name nginx --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
 
-      - name: Create Azure app service plan
-        if: success()
-        run: |
-          az appservice plan create --resource-group ${{env.AZURE_RESOURCE_GROUP}} --name ${{env.AZURE_APP_PLAN}} --is-linux --sku F1 --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+          - name: Configure webapp to use GHCR
+            if: success()
+            run: |
+              az webapp config container set --docker-custom-image-name nginx --docker-registry-server-password ${{secrets.CR_PAT}} --docker-registry-server-url https://${{env.IMAGE_REGISTRY_URL}} --docker-registry-server-user ${{github.actor}} --name ${{ env.AZURE_WEBAPP_NAME }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
 
-      - name: Create webapp resource
-        if: success()
-        run: |
-          az webapp create --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --plan ${{ env.AZURE_APP_PLAN }} --name ${{ env.AZURE_WEBAPP_NAME }}  --deployment-container-image-name nginx --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+      destroy-azure-resources:
+        runs-on: ubuntu-latest
 
-      - name: Configure webapp to use GHCR
-        if: success()
-        run: |
-          az webapp config container set --docker-custom-image-name nginx --docker-registry-server-password ${{secrets.CR_PAT}} --docker-registry-server-url https://${{env.IMAGE_REGISTRY_URL}} --docker-registry-server-user ${{github.actor}} --name ${{ env.AZURE_WEBAPP_NAME }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+        if: contains(github.event.pull_request.labels.*.name, 'destroy environment')
 
-  destroy-azure-resources:
-    runs-on: ubuntu-latest
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@v4
 
-    if: contains(github.event.pull_request.labels.*.name, 'destroy environment')
+          - name: Azure login
+            uses: azure/login@v2
+            with:
+              creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Azure login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: Destroy Azure environment
-        if: success()
-        run: |
-          az group delete --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}} --yes
-```
-
-3. Click **Commit changes...** and select `Commit directly to the azure-configuration branch.` before clicking **Commit changes**.
-4. Go to the Pull requests tab of the repository.
-5. There should be a yellow banner with the `azure-configuration` branch where you can click **Compare & pull request**.
-6. Set the title of the Pull request to: `Added spinup-destroy.yml workflow` and click `Create pull request`.
+          - name: Destroy Azure environment
+            if: success()
+            run: |
+              az group delete --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}} --yes
+    ```
+1. Click **Commit changes...** and select `Commit directly to the azure-configuration branch.` before clicking **Commit changes**.
+1. Go to the Pull requests tab of the repository.
+1. There should be a yellow banner with the `azure-configuration` branch where you can click **Compare & pull request**.
+1. Set the title of the Pull request to: `Added spinup-destroy.yml workflow` and click `Create pull request`.
 
 We will cover the key functionality below and then put the workflow to use by applying a label to the pull request.
 

--- a/.github/steps/3-spinup-environment.md
+++ b/.github/steps/3-spinup-environment.md
@@ -23,7 +23,7 @@ Through the power of GitHub Actions, we can create, configure, and destroy these
 Personal access tokens (PATs) are an alternative to using passwords for authentication to GitHub. We will use a PAT to allow your web app to pull the container image after your workflow pushes a newly built image to the registry.
 
 1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab.
-2. Create a personal access token with the `repo` and `read:packages` scopes. For more information, see ["Creating a personal access token."](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+2. Create a personal access token with the `repo` and `write:packages` scopes. For more information, see ["Creating a personal access token."](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 3. Once you have generated the token we will need to store it in a secret so that it can be used within a workflow. Create a new repository secret named `CR_PAT` and paste the PAT token in as the value.
 4. With this done we can move on to setting up our workflow.
 

--- a/.github/steps/5-deploy-to-prod-environment.md
+++ b/.github/steps/5-deploy-to-prod-environment.md
@@ -74,7 +74,7 @@ jobs:
         with:
           registry: ${{ env.IMAGE_REGISTRY_URL }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -106,7 +106,7 @@ jobs:
         with:
           login-server: ${{env.IMAGE_REGISTRY_URL}}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: Deploy web app container
         uses: azure/webapps-deploy@v3


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This PR fixes the course, although we will continue to see deprecation warnings from using  the `--sdk-auth` flag. I'm not finding much evidence that support for this flag will actually be removed any time soon. See https://github.com/Azure/azure-cli/issues/20743 and https://github.com/Azure/azure-cli/issues/19949#issuecomment-951503494 for more information, but the tldr is that flag gives us what we need for this course and there's consensus that, although maybe eventually deprecated, this flag outputs the proper credentials which is preferable to the alternatives. The alternatives include breaking context to create some credentials in the Azure Portal or doing recommended OIDC auth but that requires breaking context even further. 

There's a good argument to be made that this course can and probably should be rewritten and slimmed down significantly, but this PR gets it to a working state so users aren't struggling to follow a patchwork of documentation.

### Changes
<!-- Describe the changes this pull request introduces. -->

- Revert https://github.com/skills/deploy-to-azure/pull/78
- Updates instructions so that the user gives their `CR_PAT` `write:packages` permissions, required to update or publish a package. 
- Updates user-created workflows to utilize `CR_PAT`, which wasn't used at all.
- Fix indentation and step numbering for most steps. 

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/deploy-to-azure/issues/84

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
